### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ to `/opt/stackstorm/configs/docker.yaml` and edit as required.
 
 These options mirror the options of docker CLI.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Notes
 
 If you are connecting to the Docker daemon via the Unix socket, you need to

--- a/actions/build_image.yaml
+++ b/actions/build_image.yaml
@@ -1,6 +1,6 @@
 ---
 name: build_image
-runner_type: run-python
+runner_type: python-script
 description: Build docker image action. Equivalent to docker build.
 enabled: true
 entry_point: build_image.py

--- a/actions/pull_image.yaml
+++ b/actions/pull_image.yaml
@@ -1,6 +1,6 @@
 ---
 name: pull_image
-runner_type: run-python
+runner_type: python-script
 description: Pull docker image action. Equivalent to docker pull.
 enabled: true
 entry_point: pull_image.py

--- a/actions/push_image.yaml
+++ b/actions/push_image.yaml
@@ -1,6 +1,6 @@
 ---
 name: push_image
-runner_type: run-python
+runner_type: python-script
 description: Push docker image action. Equivalent to docker push.
 enabled: true
 entry_point: push_image.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords :
   - containers
   - virtualization
   - cgroups
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.